### PR TITLE
Cypress.log() lacks a way to highlight a DOM element

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -33,7 +33,12 @@ Cypress.Commands.add("visualSnapshot", (maybeName) => {
 });
 
 Cypress.Commands.add("getBySel", (selector, ...args) => {
-  return cy.get(`[data-test=${selector}]`, ...args);
+    Cypress.log({
+        name: "getBySel",
+        message: selector
+    });
+
+    return cy.get(`[data-test=${selector}]`, {log: false});
 });
 
 Cypress.Commands.add("getBySelLike", (selector, ...args) => {

--- a/cypress/tests/ui/user-settings.spec.ts
+++ b/cypress/tests/ui/user-settings.spec.ts
@@ -19,7 +19,7 @@ describe("User Settings", function () {
     cy.getBySel("sidenav-user-settings").click();
   });
 
-  it("renders the user settings form", function () {
+  it.only("renders the user settings form", function () {
     cy.wait("@getNotifications");
     cy.getBySel("user-settings-form").should("be.visible");
     cy.location("pathname").should("include", "/user/settings");


### PR DESCRIPTION
This PR is an example for https://github.com/cypress-io/cypress/issues/15859.